### PR TITLE
[FEATURE] Add db_dump script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN sed -i 's/^#default-character-set/default-character-set/' /etc/mysql/conf.d/
 	sed -i 's/^#collation_server/collation_server/' /etc/mysql/conf.d/mariadb.cnf
 
 COPY assets/pre-entrypoint.sh /pre-entrypoint.sh
+COPY assets/db_dump /usr/local/bin/db_dump
+
 RUN cat /pre-entrypoint.sh /docker-entrypoint.sh > /temp-entrypoint.sh ; rm /docker-entrypoint.sh ; mv /temp-entrypoint.sh /docker-entrypoint.sh ; chmod +x /docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+Docker MariaDB
+==============
+
+DB export
+---------
+You can create database dumps with the `db_dump` command. There are no credentials necessary to run this command. And you can add custom parameters (e.g. `--no-data`)
+
+
+* Output dump on STDOUT
+  ```
+  docker exec <DOCKER-CONTAINER-NAME> db_dump
+  ```
+
+* Output dump on STDOUT (with custom parameters)
+  ```
+  docker exec <DOCKER-CONTAINER-NAME> db_dump --no-data
+  ```
+
+* Save dump in file
+  ```
+  docker exec <DOCKER-CONTAINER-NAME> db_dump > `date +%Y%m%d`.sql
+  ```
+
+* Save dump in compressed file
+  ```
+  docker exec <DOCKER-CONTAINER-NAME> db_dump | gzip -9 > `date +%Y%m%d`.sql.gz
+  ```
+

--- a/assets/db_dump
+++ b/assets/db_dump
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/mysqldump --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" $1


### PR DESCRIPTION
Allows to easily perform database dumps. The script accepts custom
parameters. e.g.

```
docker exec <DOCKER-CONTAINER-NAME> db_dump
```